### PR TITLE
fix: Add required owner field to marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,9 @@
 {
   "name": "vue-skills",
   "description": "A collection of skills for Vue.js development.",
+  "owner": {
+    "name": "vuejs-ai"
+  },
   "plugins": [
     {
       "name": "create-adaptable-composable",


### PR DESCRIPTION
 ## Issue
  Fixes #31

  ## Problem
  The `marketplace.json` file was missing the required `owner` field, causing Claude Code installation to fail with:
  4. Error: Invalid schema: owner: Invalid input: expected object, received undefined

  ## Solution
  Added the `owner` field with the organization name "vuejs-ai" to `.claude-plugin/marketplace.json`.

  ## Testing
  This change enables successful installation via:
  - `/plugin marketplace add vuejs-ai/skills`
  - `npx skills add vuejs-ai/skills`

  ## Changes
  - Added `owner` object with `name: "vuejs-ai"` to marketplace.json