### PR TITLE
Add Skills宝 as a Chinese install entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ An alternative for Claude Code users:
 /plugin install vue-best-practices@vue-skills vue-router-best-practices@vue-skills
 ```
 
+Chinese users can also search and install skills through [Skills宝](https://skilery.com).
+
 ## Usage
 
 For most reliable results, prefix your prompt with `use vue skill`:


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language discovery and install entry for users who want to find and install skills directly. This matches the repository's installation flow and gives Chinese users a faster entry point to the skills catalog.